### PR TITLE
Use secrets manager for credentials to external S3 providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,10 @@ current run. Discover granules handles the following possible values:
    this run
  - replace: Existing granule records in the database will be ignored and discovered as if they were new
 
+# S3 Authentication via Secrets Manager
+GDG can perform granule discovery on S3 providers using credentials stored in an AWS Secrets Manager. This is supported by
+defining `collection.meta.aws_secret_name` as the name or ARN of the Secrets Manager. Credentials should be stored in the Secrets Manager using the `aws_access_key_id` and `aws_secret_access_key` keys.
+
 # Lambda Output
 The following is an example of the modified `discover_tf` block that the GDG lambda will produce:
 ```json

--- a/modules/ghrc_discover_granules_lambda/main.tf
+++ b/modules/ghrc_discover_granules_lambda/main.tf
@@ -37,24 +37,26 @@ resource "aws_lambda_function" "ghrc_discover_granules" {
     aws_secretsmanager_secret.gdg_db_credentials]
 }
 
-resource "aws_iam_policy" "ssm_policy" {
+resource "aws_iam_policy" "secrets_policy" {
   policy = jsonencode(
   {
     Version = "2012-10-17"
     "Statement" = [
       {
-        Effect = "Allow",
-        Action = "ssm:GetParameter",
+        Effect   = "Allow"
+        Action   = [
+          "secretsmanager:GetSecretValue"
+        ]
         Resource = [
-          "arn:aws:ssm:*"
+          "arn:aws:secretsmanager:*"
         ]
       }
     ]
   })
 }
 
-resource "aws_iam_role_policy_attachment" "glm_ssm_policy_attach" {
-  policy_arn = aws_iam_policy.ssm_policy.arn
+resource "aws_iam_role_policy_attachment" "glm_secrets_policy_attach" {
+  policy_arn = aws_iam_policy.secrets_policy.arn
   role = var.cumulus_lambda_role_name
 }
 

--- a/task/dbm_base.py
+++ b/task/dbm_base.py
@@ -121,7 +121,7 @@ class DBManagerPeewee(DBManagerBase):
     def close_db(self):
         self.database.close()
         if self.cumulus_filter:
-            self.cumulus_filter.close_db()
+            self.cumulus_dbm.close_db()
 
     def db_replace(self):
         raise NotImplementedError

--- a/task/discover_granules_base.py
+++ b/task/discover_granules_base.py
@@ -96,7 +96,7 @@ class DiscoverGranulesBase(ABC):
             cumulus_kwargs.update({'db_type': 'cumulus', 'database': None})
             cumulus_dbm = get_db_manager(**cumulus_kwargs)
             kwargs.update({
-                'cumulus_filter_dbm': cumulus_dbm
+                'cumulus_dbm': cumulus_dbm
             })
 
         self.dbm = get_db_manager(**kwargs)

--- a/task/discover_granules_s3.py
+++ b/task/discover_granules_s3.py
@@ -23,8 +23,10 @@ def get_secret_value(secret_name, secrets_client):
     
     try:
         return json.loads(secret_string)
-    except (json.JSONDecodeError, TypeError):
-        return secret_string
+    except (json.JSONDecodeError, TypeError) as e:
+        gdg_logger.error(f'Failed to parse secret string: {secret_string}. '\
+                         'Expected a JSON string with keys "aws_access_key_id" and "aws_secret_access_key".')
+        raise e
 
 
 def get_s3_client(aws_key_id=None, aws_secret_key=None):

--- a/task/discover_granules_s3.py
+++ b/task/discover_granules_s3.py
@@ -1,6 +1,7 @@
 import concurrent.futures
 import os
 import re
+import json
 
 import boto3
 
@@ -10,14 +11,20 @@ from task.logger import gdg_logger
 ONE_MEBIBIT = 1048576
 
 
-def get_ssm_value(id_name, ssm_client):
+def get_secret_value(secret_name, secrets_client):
     """
-    Retrieves and decrypts ssm value from aws
-    :param id_name: The identifier of the managed secret
-    :param ssm_client:Initialized boto3 ssm client
-    :return: Decrypted ssm value
+    Retrieves and parses a JSON secret from AWS Secrets Manager
+    :param secret_name: Name or ARN of the secrets manager
+    :param secrets_client: Initialized boto3 secretsmanager client
+    :return: Dict containing access keys
     """
-    return ssm_client.get_parameter(Name=id_name, WithDecryption=True).get('Parameter').get('Value')
+    response = secrets_client.get_secret_value(SecretId=secret_name)
+    secret_string = response.get('SecretString')
+    
+    try:
+        return json.loads(secret_string)
+    except (json.JSONDecodeError, TypeError):
+        return secret_string
 
 
 def get_s3_client(aws_key_id=None, aws_secret_key=None):
@@ -34,15 +41,18 @@ def get_s3_client(aws_key_id=None, aws_secret_key=None):
     )
 
 
-def get_s3_client_with_keys(key_id_name, secret_key_name):
+def get_s3_client_from_secret(secret_name):
     """
-    Gets a boto3 s3 client using an aws key id and secret key if provided
-    :param key_id_name: ID of the aws key
-    :param secret_key_name: Name of the aws key
+    Gets an S3 client using keys stored in a Secrets Manager
+    :param secret_name: Name or ARN of the secret containing credentials
     """
-    ssm_client = boto3.client('ssm')
-    return get_s3_client(aws_key_id=get_ssm_value(key_id_name, ssm_client),
-                         aws_secret_key=get_ssm_value(secret_key_name, ssm_client))
+    secrets_client = boto3.client('secretsmanager')
+    secret_data = get_secret_value(secret_name, secrets_client)
+    
+    return get_s3_client(
+        aws_key_id=secret_data.get('aws_access_key_id'),
+        aws_secret_key=secret_data.get('aws_secret_access_key')
+    )
 
 
 def get_s3_resp_iterator(host, prefix, s3_client, pagination_config=None, start_after=''):
@@ -72,8 +82,7 @@ class DiscoverGranulesS3(DiscoverGranulesBase):
     """
     def __init__(self, event, context):
         super().__init__(event, context=context)
-        self.key_id_name = self.meta.get('aws_key_id_name')
-        self.secret_key_name = self.meta.get('aws_secret_key_name')
+        self.secret_key_name = self.meta.get('aws_secret_name')
         self.prefix = str(self.collection['meta']['provider_path']).lstrip('/')
         self.bookmark = self.discover_tf.get('bookmark', '')
         self.early_return_threshold = int(os.getenv('early_return_threshold', 0)) * 1000
@@ -82,8 +91,8 @@ class DiscoverGranulesS3(DiscoverGranulesBase):
         ret = {}
         try:
             gdg_logger.info(f'Discovering in {self.provider_url}')
-            s3_client = get_s3_client() if None in [self.key_id_name, self.secret_key_name] \
-                else get_s3_client_with_keys(self.key_id_name, self.secret_key_name)
+            s3_client = get_s3_client() if not self.secret_key_name \
+                else get_s3_client_from_secret(self.secret_key_name)
             start_after = self.discover_tf.get('bookmark', '')
             self.bookmark = self.discover(get_s3_resp_iterator(
                 self.host, self.prefix, s3_client, start_after=start_after)
@@ -239,7 +248,7 @@ class DiscoverGranulesS3(DiscoverGranulesBase):
 
     def move_granule_wrapper(self, granule_list_dicts):
         gdg_logger.info(f'Moving granules to internal bucket')
-        external_s3_client = get_s3_client_with_keys(self.key_id_name, self.secret_key_name)
+        external_s3_client = get_s3_client_from_secret(self.secret_key_name)
         internal_s3_client = get_s3_client()
         with concurrent.futures.ThreadPoolExecutor() as executor:
             futures = []

--- a/task/lambda.py
+++ b/task/lambda.py
@@ -1,7 +1,6 @@
 import os
 import sys
 
-from task.test import test_main
 from task.logger import gdg_logger
 from task.main import main
 
@@ -12,12 +11,9 @@ if os.environ.get('CUMULUS_MESSAGE_ADAPTER_DIR'):
 
 def handler(event, context):
     # gdg_logger.info(f'Full Event: {event}')
-    if event.get('is_test', False):
-        results = test_main(event, context)
+    if run_cumulus_task:
+        results = run_cumulus_task(main, event, context)
+        # gdg_logger.info(f'result: {results}')
     else:
-        if run_cumulus_task:
-            results = run_cumulus_task(main, event, context)
-            # gdg_logger.info(f'result: {results}')
-        else:
-            results = main(event, context)
+        results = main(event, context)
     return results

--- a/task/main.py
+++ b/task/main.py
@@ -62,7 +62,7 @@ def main(event, context):
         # If keys were provided then we need to relocate the granules to the GHRC private bucket so the sync granules
         # step will be able to copy them. As of 06-17-2022 Cumulus sync granules does not support access keys.
         # Additionally the provider needs to be updated to use the new location.
-        if dg_client.meta.get('aws_key_id_name', None) and dg_client.meta.get('aws_secret_key_name', None):
+        if dg_client.meta.get('aws_secret_name', None):
             gdg_logger.info('Granules are in an external provider. Updating output to internal bucket.')
             dg_client.move_granule_wrapper(granule_list_dicts)
             external_host = dg_client.provider.get('external_host', None)

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -2,7 +2,6 @@ services:
 
   psql_db:
     image: postgres
-    restart: always
     # set shared memory limit when using docker compose
     shm_size: 128mb
     environment:

--- a/tests/test_discover_granules_s3.py
+++ b/tests/test_discover_granules_s3.py
@@ -2,6 +2,7 @@ import datetime
 import os
 import time
 import pytest
+import json
 from dateutil.tz import tzutc
 
 from task.discover_granules_s3 import DiscoverGranulesS3, get_secret_value, get_s3_client, get_s3_client_from_secret, \
@@ -32,13 +33,27 @@ def test_get_secret_value(mocker):
     assert 'aws_access_key_id' in ret and 'aws_secret_access_key' in ret
 
 
+def test_get_secret_value_failure(mocker):
+    mock_secrets = mocker.patch('boto3.client')
+    mock_secrets.get_secret_value.return_value = {
+        'SecretString': 'unexpected secret string'
+    }
+    with pytest.raises((json.JSONDecodeError, TypeError)):
+        ret = get_secret_value('fake_secret_manager', mock_secrets)
+
+
 def test_get_s3_client(mocker):
     test_client = get_s3_client()
     assert test_client is not None
 
 
 def test_get_s3_client_from_secret(mocker):
-    mock_secrets = mocker.patch('boto3.client')
+    mock_client = mocker.patch('boto3.client')
+    mock_get_secrets = mocker.patch('task.discover_granules_s3.get_secret_value')
+    mock_get_secrets.return_value = {
+        "aws_access_key_id": "aws_access_key_id",
+        "aws_secret_access_key": "aws_secret_access_key"
+    }
     test_client = get_s3_client_from_secret('fake_secret_manager')
     assert test_client is not None
 
@@ -155,6 +170,11 @@ def test_move_granule_multipart(mocker, discover_granules_s3):
 
 def test_move_granule_wrapper(mocker, discover_granules_s3):
     mock_client = mocker.patch('boto3.client')
+    mock_get_secrets = mocker.patch('task.discover_granules_s3.get_secret_value')
+    mock_get_secrets.return_value = {
+        "aws_access_key_id": "aws_access_key_id",
+        "aws_secret_access_key": "aws_secret_access_key"
+    }
     dg = discover_granules_s3('skip_s3')
     mocker.patch.object(dg, 'move_granule')
     test_list_dict = [

--- a/tests/test_discover_granules_s3.py
+++ b/tests/test_discover_granules_s3.py
@@ -4,7 +4,7 @@ import time
 import pytest
 from dateutil.tz import tzutc
 
-from task.discover_granules_s3 import DiscoverGranulesS3, get_ssm_value, get_s3_client, get_s3_client_with_keys, \
+from task.discover_granules_s3 import DiscoverGranulesS3, get_secret_value, get_s3_client, get_s3_client_from_secret, \
     ONE_MEBIBIT
 
 
@@ -23,12 +23,13 @@ def discover_granules_s3(get_event):
     return gen_dg_s3
 
 
-def test_get_ssm(mocker):
-    mock_ssm = mocker.patch('boto3.client')
-    mock_ssm.get_parameter.return_value = {'Parameter': {'Value': 'test_value'}}
-    ret = get_ssm_value('test_name', mock_ssm)
-    
-    assert ret == 'test_value'
+def test_get_secret_value(mocker):
+    mock_secrets = mocker.patch('boto3.client')
+    mock_secrets.get_secret_value.return_value = {
+        'SecretString': '{\"aws_access_key_id\": \"aws_access_key_id\", \"aws_secret_access_key\": \"aws_secret_access_key\"}'
+    }
+    ret = get_secret_value('fake_secret_manager', mock_secrets)
+    assert 'aws_access_key_id' in ret and 'aws_secret_access_key' in ret
 
 
 def test_get_s3_client(mocker):
@@ -36,13 +37,13 @@ def test_get_s3_client(mocker):
     assert test_client is not None
 
 
-def test_get_s3_client_with_keys(mocker):
-    mock_ssm = mocker.patch('boto3.client')
-    test_client = get_s3_client_with_keys('test_key_id', 'test_secret_key')
+def test_get_s3_client_from_secret(mocker):
+    mock_secrets = mocker.patch('boto3.client')
+    test_client = get_s3_client_from_secret('fake_secret_manager')
     assert test_client is not None
 
 
-def test__discover_granules_s3(discover_granules_s3):
+def test_discover_granules_s3(discover_granules_s3):
     dg = discover_granules_s3('skip_s3')
     test_resp_iter = [
         {


### PR DESCRIPTION
- Added Secrets Manager support for external S3 provider authentication. Tested on legacy stack with glmgoesL3.
- Old SSM functionality was commented instead of removed in case it for some reason needs to be temporarily restored for consolidated stacks.
- Quick fix to bug when using `cumulus_filter`.